### PR TITLE
Lock entire record

### DIFF
--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -94,13 +94,19 @@ class LockingAPI extends AbstractExternalModule
                 if (!isset($this->Proj)) { throw new Exception("Can't validate POST params without first setting Proj."); }
                 $this->returnFormat = $this->validateReturnFormat();
                 $this->lock_record_level = $this->validateLockRecordLevel();
-                $this->format = $this->validateFormat();                
+                $this->format = $this->validateFormat();
                 $this->record = $this->validateRecord();
-                $this->event_id = $this->validateEvent();
-                $this->instrument = $this->validateInstrument();
-                $this->instance = $this->validateInstance();
-                $this->arm = $this->validateArm();
 
+                # Validate on data level
+                if( !$this->lock_record_level) {
+                        $this->event_id = $this->validateEvent();
+                        $this->instrument = $this->validateInstrument();
+                        $this->instance = $this->validateInstance();
+                } 
+                # Validate on record level
+                else {
+                        $this->arm = $this->validateArm();
+                }
         }
         
         protected function validateReturnFormat() {
@@ -115,11 +121,11 @@ class LockingAPI extends AbstractExternalModule
                         : 'xml';
         }
 
-        protected function validateLockRecordLevel() {
-                $lock_record_level = false;
+        protected function validateLockRecordLevel() :bool {
+                $lock_record_level = (bool) false;
                 # Check if is set and 'true' or true (boolean)
                 if(isset($this->post['lock_record_level'])  && $this->post['lock_record_level']!=='' && ($this->post['lock_record_level'] === 'true' || $this->post['lock_record_level'] === true) ) {
-                        $lock_record_level = $this->post['lock_record_level'];
+                        $lock_record_level = true;
                 }
 
                 return $lock_record_level;

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -230,6 +230,7 @@ class LockingAPI extends AbstractExternalModule
 
                         if($this->post['format'] == 'json') {
 
+                                # Disallow json format on data level since it is not supported yet. TBD
                                 if($this->lock_record_level != true) {
                                         self::errorResponse("JSON format is not yet supported for this type of request.");
                                         exit();
@@ -248,7 +249,7 @@ class LockingAPI extends AbstractExternalModule
                         # Check if arm exists
                         if( isset($this->Proj->events[$this->post['arm']]['id']) ) {                                
                                 # Check if record exists within arm                                                              
-                                $recordInArm = $recordInArm = count(\Records::getRecordList( $this->project_id, array(), false, false, $this->post['arm'], null, 0, $this->record ));
+                                $recordInArm = count(\Records::getRecordList( $this->project_id, array(), false, false, $this->post['arm'], null, 0, $this->record ));
 
                                 if( $recordInArm > 0 ) {
                                         $arm = $this->post['arm'];
@@ -380,7 +381,8 @@ class LockingAPI extends AbstractExternalModule
                 ',
                 [                        
                         $this->project_id,
-                        $this->arm_id
+                        # Get arm id from arm
+                        $this->Proj->events[$this->arm]['id']
                 ]);                
                 $query->add('and')->addInClause('record', $this->record);
 
@@ -401,7 +403,8 @@ class LockingAPI extends AbstractExternalModule
                                 "lr_id" => null,
                                 "project_id" => $this->project_id,
                                 "record" => $unlocked_record, 
-                                "arm_id" => $this->arm_id, 
+                                # Get arm id from arm
+                                "arm_id" => $this->Proj->events[$this->arm]['id'], 
                                 "username" =>  null,
                                 "timestamp" => null
                         );

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -47,7 +47,6 @@ class LockingAPI extends AbstractExternalModule
         private $lock_status;
         private $lock_record_level;
         private $arm;
-        private $test;
 
         public function __construct() {
                 parent::__construct();
@@ -316,9 +315,6 @@ class LockingAPI extends AbstractExternalModule
         
                 if($this->lock_record_level == true) {
                         $this->handleLockRecordLevel($lock);
-                        return $this->test;
-                        //$test = count(\Records::getRecordList( $this->project_id, array(), false, false, $this->arm, null, 0, $this->record ));
-
                         return "Entire Record(s) have been unlocked/locked.";
                 }
                 else {

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -47,6 +47,7 @@ class LockingAPI extends AbstractExternalModule
         private $lock_status;
         private $lock_record_level;
         private $arm;
+        private $test;
 
         public function __construct() {
                 parent::__construct();
@@ -191,11 +192,19 @@ class LockingAPI extends AbstractExternalModule
         }
 
         public function validateArm() {
-                $arm = 1;
                 if( isset($this->post['arm']) && $this->post['arm']!=='' ) {
-                        // Check if arm exists
-                        if( isset($this->Proj->events[$this->post['arm']]['id']) ) {
-                                $arm = $this->post['arm'];                                
+                        # Check if arm exists
+                        if( isset($this->Proj->events[$this->post['arm']]['id']) ) { 
+                                # Check if record exists within arm                                                              
+                                $recordInArm = $recordInArm = count(\Records::getRecordList( $this->project_id, array(), false, false, $this->post['arm'], null, 0, $this->record ));
+
+                                if( $recordInArm > 0 ) {
+                                        $arm = $this->post['arm'];
+                                }
+                                else {
+                                        $invalid_arm = $this->post['arm'];
+                                        self::errorResponse("Record with ID $this->record is not included in arm $invalid_arm");   
+                                }
                         }
                         else {
                                 self::errorResponse("Invalid arm $arm"); 
@@ -307,6 +316,9 @@ class LockingAPI extends AbstractExternalModule
         
                 if($this->lock_record_level == true) {
                         $this->handleLockRecordLevel($lock);
+                        return $this->test;
+                        //$test = count(\Records::getRecordList( $this->project_id, array(), false, false, $this->arm, null, 0, $this->record ));
+
                         return "Entire Record(s) have been unlocked/locked.";
                 }
                 else {

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -126,7 +126,7 @@ class LockingAPI extends AbstractExternalModule
                         $records = array();
 
                         if(is_array($this->post['record'])) {
-                                # Support array parameter via curl
+                                # Support array parameter via php/curl
                                 $records = $this->post['record'];
                         } else {
                                 # Transform json into array
@@ -416,19 +416,29 @@ class LockingAPI extends AbstractExternalModule
                         $response = json_encode($this->lock_record_status);
                 }
                 else if($this->returnFormat == 'csv') {
-                        $response = implode (",", array_keys( (array) $this->lock_record_status))."\n";
-                        $response .= implode (", ",  (array) $this->lock_record_status);
+
+                        # Generate csv header from first object element, using object{0} to access
+                        $response = implode(",", array_keys($this->lock_record_status{0}))."\n";
+                        # Add rows as comma-separated list
+                        foreach((array) $this->lock_record_status as $row) {
+                                $response .= implode (", ", $row)."\n";
+                        }
+                        
                 }
                 else {
-                        $response = '<?xml version="1.0" encoding="UTF-8" ?><lock_record_level_status>';
+                        $response = '<?xml version="1.0" encoding="UTF-8" ?>';
 
-                        foreach($this->lock_record_status as $key => $value) {
-                                $response .= "<$key>$value</$key>";
-                        }
+                        foreach($this->lock_record_status as $status) {
+                                $response .= '<lock_record_level_status>';
 
-                        $response .= "</lock_record_level_status>";
+                                foreach($status as $key => $value) {
+                                        $response .= "<$key>$value</$key>";
+                                }
+                                $response .= '</lock_record_level_status>';
+                        }                        
+                        $response .= "</xml>";
                 }
-
+                # Send response with correct formatting
                 RestUtility::sendResponse(200, $response, $this->returnFormat);
                 
         }

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -115,6 +115,35 @@ class LockingAPI extends AbstractExternalModule
                         : 'xml';
         }
 
+        protected function validateLockRecordLevel() {
+                $lock_record_level = false;
+                # Check if is set and 'true' or true (boolean)
+                if(isset($this->post['lock_record_level'])  && $this->post['lock_record_level']!=='' && ($this->post['lock_record_level'] === 'true' || $this->post['lock_record_level'] === true) ) {
+                        $lock_record_level = $this->post['lock_record_level'];
+                }
+
+                return $lock_record_level;
+        }
+
+        public function validateFormat() {
+                $format = "";
+                if(isset($this->post['format']) && $this->post['format']!=='' ) {
+
+                        if($this->post['format'] == 'json') {
+
+                                # Disallow json format on data level since it is not supported yet. TBD
+                                if($this->lock_record_level != true) {
+                                        self::errorResponse("JSON format is not yet supported for this type of request.");
+                                        exit();
+                                }
+
+                                $format = $this->post['format'];
+                        }
+                }
+
+                return $format;
+        }
+
         protected function validateRecord() {
                 if (!isset($this->post['record']) || $this->post['record']==='') {
                         self::errorResponse("Record(s) not supplied.");
@@ -213,34 +242,6 @@ class LockingAPI extends AbstractExternalModule
                         }
                 }
                 return $instance;
-        }
-
-        protected function validateLockRecordLevel() {
-                $lock_record_level = false;
-                if(isset($this->post['lock_record_level'])  && $this->post['lock_record_level']!=='' && $this->post['lock_record_level']!== 'false' ) {
-                        $lock_record_level = $this->post['lock_record_level'];
-                }
-
-                return $lock_record_level;
-        }
-
-        public function validateFormat() {
-                $format = "";
-                if(isset($this->post['format']) && $this->post['format']!=='' ) {
-
-                        if($this->post['format'] == 'json') {
-
-                                # Disallow json format on data level since it is not supported yet. TBD
-                                if($this->lock_record_level != true) {
-                                        self::errorResponse("JSON format is not yet supported for this type of request.");
-                                        exit();
-                                }
-
-                                $format = $this->post['format'];
-                        }
-                }
-
-                return $format;
         }
 
         public function validateArm() {

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -3,7 +3,7 @@
  * REDCap External Module: Locking API
  * Lock, unlock and read the lock status of instruments and entire records using API calls
  * @author Luke Stevens, Murdoch Children's Research Institute
- * @author Ekin Tertemiz, Swiss Tropical and Public Health Institute
+ * contributor: Ekin Tertemiz, Swiss Tropical and Public Health Institute
  * 
  */
 namespace MCRI\LockingAPI;

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -257,7 +257,17 @@ class LockingAPI extends AbstractExternalModule
 
                 $this->lock_status = $eventForms;
         }
-        
+
+        public function handleWholeLock($lock) {
+                $isWholeRecordLocked = \Locking::isWholeRecordLocked($this->project_id, $this->record, $this->arm_id);
+                if($lock == true && !$isWholeRecordLocked) {
+                        \Locking::lockWholeRecord($this->project_id, $this->record, $this->arm_id);
+                } 
+                else if ($lock == false && $isWholeRecordLocked) {
+                        \Locking::unlockWholeRecord($this->project_id, $this->record, $this->arm_id);
+                }
+        }
+       
         public function readStatus() {
                 $this->processLockingApiRequest();
                 $this->readCurrentLockStatus();
@@ -276,7 +286,9 @@ class LockingAPI extends AbstractExternalModule
                 $this->processLockingApiRequest();
 
                 if($this->whole_record === true) {
-                        // TBD $this->handleWholeLock()
+
+                        $this->handleWholeLock($lock);
+                        # public function lockWholeRecord($project_id, $record, $arm=1)
                         return "Entire Record(s) have been locked.";
                 }
                 else {

--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -45,7 +45,7 @@ class LockingAPI extends AbstractExternalModule
         private $instrument;
         private $instance;
         private $lock_status;
-        private $whole_record;
+        private $lock_record_level;
 
         public function __construct() {
                 parent::__construct();
@@ -93,7 +93,7 @@ class LockingAPI extends AbstractExternalModule
                 $this->event_id = $this->validateEvent();
                 $this->instrument = $this->validateInstrument();
                 $this->instance = $this->validateInstance();
-                $this->whole_record = $this->validateWholeRecord();
+                $this->lock_record_level = $this->validateLockRecordLevel();
         }
         
         protected function validateReturnFormat() {
@@ -178,10 +178,13 @@ class LockingAPI extends AbstractExternalModule
                 return $instance;
         }
 
-        protected function validateWholeRecord() {
-                $whole_record = false;
+        protected function validateLockRecordLevel() {
+                $lock_record_level = false;
+                if(isset($this->post['lock_record_level'])) {
+                        $lock_record_level = $this->post['lock_record_level'];
+                }
                 // TBD
-                return $whole_record;
+                return $lock_record_level;
         }
         
         public function readCurrentLockStatus() {
@@ -258,7 +261,7 @@ class LockingAPI extends AbstractExternalModule
                 $this->lock_status = $eventForms;
         }
 
-        public function handleWholeLock($lock) {
+        public function handleLockRecordLevel(bool $lock) {
                 $isWholeRecordLocked = \Locking::isWholeRecordLocked($this->project_id, $this->record, $this->arm_id);
                 if($lock == true && !$isWholeRecordLocked) {
                         \Locking::lockWholeRecord($this->project_id, $this->record, $this->arm_id);
@@ -285,9 +288,9 @@ class LockingAPI extends AbstractExternalModule
         protected function updateLockStatus($lock=true) {
                 $this->processLockingApiRequest();
 
-                if($this->whole_record === true) {
+                if($this->lock_record_level === true) {
 
-                        $this->handleWholeLock($lock);
+                        $this->handleLockRecordLevel($lock);
                         # public function lockWholeRecord($project_id, $record, $arm=1)
                         return "Entire Record(s) have been locked.";
                 }

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Arm will be ignored if Lock Record Level is false.
     page=lock&lock_record_level=true&format=json
     ```
     ```json
-    record: [{1001}, {1002}, {1003}]
+    record: [1001, 1002, 1003]
     ```
 
 
@@ -131,7 +131,7 @@ All API calls (*i.e.*, status, lock, unlock) return a set of the event/instrumen
 Note that this enables you to determine whether data has ever been entered for an instrument, which is not possible using the regular 'Export Records' or 'Export Reports' API methods. ;-) (Also note it is not possible to lock forms that have not yet had any data entry.)
 
 #### Lock Record Level
-All API calls (*i.e.*, status, lock, unlock) return the record level status for the records/arm requested.
+All API calls (*i.e.*, status, lock, unlock) return the record level status for the records/arm requested in a specified format.
 
 ### CSV Example
 
@@ -145,9 +145,8 @@ record,redcap_event_name,instrument,instance,lock_status,username,timestamp
 1001,visit_3_arm_1,visit_admin,1,,,
 ```
 
-## Min REDCap Version
-Min REDCap version is 8.2.3 due to use of array as argument to `REDCap::getData()` when checking existence of record.
-
+## Minimum REDCap Version
+Minimum REDCap version is 10.4.1 due to the necessary usage of `createQuery()` for preparing a query with "IN"-Statement.
 
 ## Contributor(s)
 Ekin Tertemiz, Swiss Tropical and Public Health Institute

--- a/README.md
+++ b/README.md
@@ -147,4 +147,9 @@ record,redcap_event_name,instrument,instance,lock_status,username,timestamp
 
 ## Min REDCap Version
 Min REDCap version is 8.2.3 due to use of array as argument to `REDCap::getData()` when checking existence of record.
+
+
+## Contributor(s)
+Ekin Tertemiz, Swiss Tropical and Public Health Institute
+
 ********************************************************************************

--- a/README.md
+++ b/README.md
@@ -6,43 +6,58 @@ Luke Stevens, Murdoch Children's Research Institute https://www.mcri.edu.au
 ********************************************************************************
 ## Summary
 
-Read lock status, lock and unlock data entry forms via API calls.
+Read lock status, lock and unlock entire records or their data entry forms via API calls. 
 
-Post api token and `record[,event][,instrument][,instance]` to your regular system API endpoint, using the following query string: 
+Post api token and `record[,event][,instrument][,instance][,arm]` to your regular system API endpoint, using the following query string: 
 
 ```http
 ?NOAUTH&type=module&prefix=locking_api&page=<action page>
 ```
 
 `<action page>` must be one of:
-* **status**: Obtain current lock state of the `record[,event][,instrument][,instance]`
-* **lock**:   Lock the `record[,event][,instrument][,instance]`
-* **unlock**: Unlock the `record[,event][,instrument][,instance]`
+* **status**: Obtain current lock state of the `record[,event][,instrument][,instance][,arm]`
+* **lock**:   Lock the `record[,event][,instrument][,instance][,arm]`
+* **unlock**: Unlock the `record[,event][,instrument][,instance][,arm]`
 
-Note it is not possible to lock a form that has not yet had any data entry.
+Note it is not possible to lock a form on data level that has not yet had any data entry.
 
 ## Example 
-
+#### Data Level
 ```bash
 curl -d "token=ABCDEF0123456789ABCDEF0123456789&returnFormat=json&record=1001&event=event_1_arm_1&instrument=medication&instance=4"
     "https://redcap.ourplace.edu/api/?NOAUTH&type=module&prefix=locking_api&page=status"
 ```
+#### Record Level
+```bash
+curl -d "token=ABCDEF0123456789ABCDEF0123456789&returnFormat=json&record=1001arm=1&lock_record_level=true"
+    "https://redcap.ourplace.edu/api/?NOAUTH&type=module&prefix=locking_api&page=status"
+```
 
 ## Return Format (optional)
-Return Format options are the usual csv, json or xml (default). 
+Return Format options are the usual csv, json or xml (default).
 
-## Record/Event/Instrument/Instance Specification
+## Lock Record Level (optional)
+Locks the entire record if set to true.
+
+## Format (optional and limited)
+JSON format allows to submit multiple records at once. Currenlty only supported in lock on record level.
+
+## Record/Event/Instrument/Instance/Arm Specification
 
 * **record**: Required. 
 * **event**: A valid unique name or event id for the project (if longitudinal).
 * **instrument**: A valid form name for the project, as per data dictionary.
 * **instance**: Instance number for repeating event or instrument.
+* **arm**: Arm number for projects with multiple arms (if Lock Record Level is used). Dafaults to 1.
 
 Event will be ignored if the project is not longitudinal.
 
 If an instance value >=2 is submitted for a non-repeating event/instrument then an error will be returned.
 
+Arm will be ignored if Lock Record Level is false.
+
 ### Examples
+#### Data Level
 * Screening form in Event 1 for record 1001 (instance not required as not a repeating form):
     ```http
     record=1001&event=event_1_arm_1&instrument=screening
@@ -78,8 +93,35 @@ If an instance value >=2 is submitted for a non-repeating event/instrument then 
     record=1001&event=event_1_arm_1&instrument=&instance=2
     ```
 
-## Returned Data
+* Error - JSON format not supported on data level:
+    ```http
+    record=1001&event=event_1_arm_1&format=json
+    ```
 
+#### Record Level
+* Get record level lock status for record 1001:
+    ```http
+    page=status&record=1001&lock_record_level=true
+    ```
+* Set record level lock for record 1001:
+    ```http
+    page=lock&record=1001&lock_record_level=true
+    ```
+* Unlock record with ID 2432:
+    ```http
+    page=unlock&record=1001&lock_record_level=true
+    ```
+* Lock multiple records 1001, 1002, 1003 using JSON format:
+    ```http
+    page=lock&lock_record_level=true&format=json
+    ```
+    ```json
+    record: [{1001}, {1002}, {1003}]
+    ```
+
+
+## Returned Data
+#### Lock Data Level
 All API calls (*i.e.*, status, lock, unlock) return a set of the event/instrument/instance combinations for the record/event/instrument/instance requested. For each combination the lock status is returned as follows:
 
 * **1**: Locked
@@ -87,6 +129,9 @@ All API calls (*i.e.*, status, lock, unlock) return a set of the event/instrumen
 * **&lt;empty&gt;**: No data exists for form
 
 Note that this enables you to determine whether data has ever been entered for an instrument, which is not possible using the regular 'Export Records' or 'Export Reports' API methods. ;-) (Also note it is not possible to lock forms that have not yet had any data entry.)
+
+#### Lock Record Level
+All API calls (*i.e.*, status, lock, unlock) return the record level status for the records/arm requested.
 
 ### CSV Example
 

--- a/config.json
+++ b/config.json
@@ -43,6 +43,6 @@
         ],
         
         "compatibility": {
-                "redcap-version-min": "8.2.3"
+                "redcap-version-min": "10.4.1"
         }
 }

--- a/config.json
+++ b/config.json
@@ -10,10 +10,15 @@
 			"name": "Luke Stevens",
 			"email": "luke.stevens@mcri.edu.au",
 			"institution": "Murdoch Children's Research Institute"
-		}
+		},
+		{
+			"name": "Ekin Tertemiz",
+			"email": "ekin.tertemiz@swisstph.ch",
+			"institution": "Swiss Tropical and Public Health Institute"
+		}		
 	],
 
-	"description": "Lock, unlock and read the lock status of instruments using API calls.",
+	"description": "Lock, unlock and read the lock status of instruments or entire records using API calls.",
         
         "permissions": [
                 "read redcap_locking_data",

--- a/config.json
+++ b/config.json
@@ -3,6 +3,8 @@
 
 	"namespace": "MCRI\\LockingAPI",
 
+	"framework-version": 6,
+
 	"authors": [
 		{
 			"name": "Luke Stevens",

--- a/lock.php
+++ b/lock.php
@@ -2,11 +2,12 @@
 /**
  * REDCap External Module: Locking API
  * @author Luke Stevens, Murdoch Children's Research Institute
+ * @author Ekin Tertemiz, Swiss Tropical and Public Health Institute
  */
 error_reporting(0);
 
 try {
-        $result = $module->lockInstruments();
+        $result = $module->updateLockStatus(true);
 } catch (Exception $ex) {
         RestUtility::sendResponse(400, $ex->getMessage());
 }

--- a/unlock.php
+++ b/unlock.php
@@ -6,7 +6,7 @@
 error_reporting(0);
 
 try {
-        $result = $module->unlockInstruments();
+        $result = $module->updateLockStatus(false);
 } catch (Exception $ex) {
         RestUtility::sendResponse(400, $ex->getMessage());
 }


### PR DESCRIPTION
This PR includes a new main feature to **lock entire record(s)**. Also for this new mode `json` input format is now supported (batch locking). The API separates between "data level lock" and "record level lock".

- the module has been upgraded to use Framework Version 6: to support `createQuery()` - otherwise there were problems with declaring the SQL "IN"-Statement. The miminum REDCap version has been updated accordingly.
- code has been refactored, renamed and cleaned
- the documentation has been updated to use "record level lock"
- different test scenarios have been made to ensure that the old API behavior and the new behavior are working smoothly together