### PR TITLE
Fix for PHP 7.4+

### DIFF
--- a/LockingAPI.php
+++ b/LockingAPI.php
@@ -503,7 +503,7 @@ class LockingAPI extends AbstractExternalModule
                 else if($this->returnFormat == 'csv') {
 
                         # Generate csv header from first object element, using object{0} to access
-                        $response = implode(",", array_keys($this->lock_record_status{0}))."\n";
+                        $response = implode(",", array_keys($this->lock_record_status[0]))."\n";
                         # Add rows as comma-separated list
                         foreach((array) $this->lock_record_status as $row) {
                                 $response .= implode (", ", $row)."\n";


### PR DESCRIPTION
Fix Syntax Error "Array and string offset access syntax with curly braces is deprecated "
that blocks REDCap from enabling the module on system level.